### PR TITLE
ci: ensure libdl available for P/Invoke in Linux build

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -52,6 +52,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential libc6-dev
+          # Workaround: ensure libdl is available for P/Invoke
+          sudo ln -sf /usr/lib/x86_64-linux-gnu/libdl.so.2 /usr/lib/libdl.so
+          echo "LD_LIBRARY_PATH=/usr/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
       - name: Run comprehensive build script (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
- install build-essential & libc6-dev as before
- add `ln -sf …/libdl.so.2 /usr/lib/libdl.so` to make libdl loadable
- export LD_LIBRARY_PATH so tests can find libdl